### PR TITLE
Fix broken URL and a ReferenceError

### DIFF
--- a/examples/online.js
+++ b/examples/online.js
@@ -1,14 +1,14 @@
 unirest = require("unirest");
 captcha = require("../CaptchaParser");
 fs = require("fs");
-var captchaUri = 'https://academics.vit.ac.in/parent/captcha.asp';
+var captchaUri = 'https://vtop.vit.ac.in/parent/captcha.asp';
 
 var onRequest = function (response) {
     if (response.error) {
         console.log('VIT Academics connection failed');
     }
     else {
-    	pixMap = getPixelMapFromBuffer(response.body);
+    	pixMap = captcha.getPixelMapFromBuffer(response.body);
     	fs.writeFileSync("captcha.bmp", response.body);
         console.log(captcha.getCaptcha(pixMap));
     }


### PR DESCRIPTION
```
/Users/jonas/tmp/CaptchaParser/examples/online.js:11
        pixMap = getPixelMapFromBuffer(response.body);
                 ^

ReferenceError: getPixelMapFromBuffer is not defined
    at onRequest (/Users/jonas/tmp/CaptchaParser/examples/online.js:11:18)
    at Request.handleRequestResponse [as _callback] (/Users/jonas/tmp/CaptchaParser/node_modules/unirest/index.js:455:25)
    at Request.self.callback (/Users/jonas/tmp/CaptchaParser/node_modules/unirest/node_modules/request/request.js:123:22)
    at emitTwo (events.js:106:13)
    at Request.emit (events.js:191:7)
    at Request.<anonymous> (/Users/jonas/tmp/CaptchaParser/node_modules/unirest/node_modules/request/request.js:1047:14)
    at emitOne (events.js:101:20)
    at Request.emit (events.js:188:7)
    at IncomingMessage.<anonymous> (/Users/jonas/tmp/CaptchaParser/node_modules/unirest/node_modules/request/request.js:998:12)
    at emitNone (events.js:91:20)
```